### PR TITLE
Added ZeroAmount for starting value for summation

### DIFF
--- a/currint/__init__.py
+++ b/currint/__init__.py
@@ -1,4 +1,4 @@
-from .amount import Amount
-from .currency import Currency, currencies
+from .amount import Amount  # noqa
+from .currency import Currency, currencies  # noqa
 
 __version__ = "1.3.1"

--- a/currint/amount.py
+++ b/currint/amount.py
@@ -61,14 +61,14 @@ class Amount(object):
         return not (self == other)
 
     def __add__(self, other):
-        if other == ZeroAmount.instance:
+        if other == _ZeroAmount.instance:
             return Amount(self.currency, self.value)
         if self.currency != other.currency:
             raise ValueError("You cannot add amounts of different currencies (%s and %s)" % (self.currency, other.currency))
         return Amount(self.currency, self.value + other.value)
 
     def __sub__(self, other):
-        if other == ZeroAmount.instance:
+        if other == _ZeroAmount.instance:
             return Amount(self.currency, self.value)
         if self.currency != other.currency:
             raise ValueError("You cannot subtract amounts of different currencies (%s and %s)" % (self.currency, other.currency))
@@ -90,7 +90,7 @@ class Amount(object):
         return self.currency.minor_to_major(self.value)
 
 
-class ZeroAmount(Amount):
+class _ZeroAmount(Amount):
     """
     Amount singleton that doesn't have any currency.
 
@@ -100,23 +100,23 @@ class ZeroAmount(Amount):
     instance = None
 
     def __init__(self):
-        super(ZeroAmount, self).__init__(None, 0)
+        super(_ZeroAmount, self).__init__(None, 0)
 
     def __new__(cls, *args, **kwargs):
         """
-        Force a singleton instance of ZeroAmount
+        Force a singleton instance of _ZeroAmount
         """
-        if not cls.instance:
-            cls.instance = super(ZeroAmount, cls).__new__(cls)
+        if cls.instance is None:
+            cls.instance = super(_ZeroAmount, cls).__new__(cls)
         return cls.instance
 
     def __add__(self, other):
-        if other == ZeroAmount.instance:
+        if other == _ZeroAmount.instance:
             return self
         return Amount(other.currency, other.value)
 
     def __sub__(self, other):
-        if other == ZeroAmount.instance:
+        if other == _ZeroAmount.instance:
             return self
         return Amount(other.currency, other.value)
 
@@ -135,4 +135,4 @@ class ZeroAmount(Amount):
         return Decimal(self.value)
 
 
-Amount.ZERO = ZeroAmount()
+Amount.ZERO = _ZeroAmount()

--- a/currint/amount.py
+++ b/currint/amount.py
@@ -61,11 +61,15 @@ class Amount(object):
         return not (self == other)
 
     def __add__(self, other):
+        if other == ZeroAmount.instance:
+            return Amount(self.currency, self.value)
         if self.currency != other.currency:
             raise ValueError("You cannot add amounts of different currencies (%s and %s)" % (self.currency, other.currency))
         return Amount(self.currency, self.value + other.value)
 
     def __sub__(self, other):
+        if other == ZeroAmount.instance:
+            return Amount(self.currency, self.value)
         if self.currency != other.currency:
             raise ValueError("You cannot subtract amounts of different currencies (%s and %s)" % (self.currency, other.currency))
         return Amount(self.currency, self.value - other.value)
@@ -84,3 +88,48 @@ class Amount(object):
     def to_major_decimal(self):
         "Returns our value as a Decimal of major units"
         return self.currency.minor_to_major(self.value)
+
+
+class ZeroAmount(Amount):
+    """
+    Amount singleton that doesn't have any currency.
+
+    It can be used as the start of a sum() operation when you don't know the
+    currency involved (yet).
+    """
+    instance = None
+
+    def __init__(self):
+        super(ZeroAmount, self).__init__(None, 0)
+
+    def __new__(cls, *args, **kwargs):
+        """
+        Force a singleton instance of ZeroAmount
+        """
+        if not cls.instance:
+            cls.instance = super(ZeroAmount, cls).__new__(cls)
+        return cls.instance
+
+    def __add__(self, other):
+        if other == ZeroAmount.instance:
+            return self
+        return Amount(other.currency, other.value)
+
+    def __sub__(self, other):
+        if other == ZeroAmount.instance:
+            return self
+        return Amount(other.currency, other.value)
+
+    def __unicode__(self):
+        return unicode(self.value)
+
+    @classmethod
+    def from_code_and_minor(cls, currency_code, value):
+        raise NotImplementedError
+
+    @classmethod
+    def from_code_and_major(cls, currency_code, value):
+        raise NotImplementedError
+
+    def to_major_decimal(self):
+        return Decimal(self.value)

--- a/currint/amount.py
+++ b/currint/amount.py
@@ -133,3 +133,6 @@ class ZeroAmount(Amount):
 
     def to_major_decimal(self):
         return Decimal(self.value)
+
+
+Amount.ZERO = ZeroAmount()

--- a/currint/tests/test_amount.py
+++ b/currint/tests/test_amount.py
@@ -158,6 +158,11 @@ class ZeroAmountTests(TestCase):
         self.assertEqual(amt.currency, self.nonzero.currency)
         self.assertEqual(amt.value, self.nonzero.value)
 
+    def test_sum_with_zeroes(self):
+        amt = sum([Amount.ZERO, self.nonzero, Amount.ZERO], Amount.ZERO)
+        self.assertEqual(amt.currency, self.nonzero.currency)
+        self.assertEqual(amt.value, self.nonzero.value)
+
     def test_to_major_decimal(self):
         self.assertEqual(Amount.ZERO.to_major_decimal(), Decimal('0'))
 

--- a/currint/tests/test_amount.py
+++ b/currint/tests/test_amount.py
@@ -136,6 +136,7 @@ class AmountTests(TestCase):
             Decimal("1.4"),  # It's written 1.2, but is 1.4 of the major unit
         )
 
+
 class ZeroAmountTests(TestCase):
     def setUp(self):
         self.nonzero = Amount(currencies["GBP"], 300)

--- a/currint/tests/test_amount.py
+++ b/currint/tests/test_amount.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from decimal import Decimal
 from unittest import TestCase
 from ..currency import currencies
-from ..amount import Amount
+from ..amount import Amount, ZeroAmount
 
 
 class AmountTests(TestCase):
@@ -135,3 +135,46 @@ class AmountTests(TestCase):
             Amount(currencies["MRO"], 7).to_major_decimal(),
             Decimal("1.4"),  # It's written 1.2, but is 1.4 of the major unit
         )
+
+class ZeroAmountTests(TestCase):
+    def setUp(self):
+        self.zero = ZeroAmount()
+        self.nonzero = Amount(currencies["GBP"], 300)
+
+    def test_simple_addition(self):
+        amt = self.zero + self.nonzero
+        self.assertEqual(amt.currency, self.nonzero.currency)
+        self.assertEqual(amt.value, self.nonzero.value)
+
+    def test_simple_raddition(self):
+        amt = self.nonzero + self.zero
+        self.assertEqual(amt.currency, self.nonzero.currency)
+        self.assertEqual(amt.value, self.nonzero.value)
+
+    def test_sum(self):
+        amt = sum([self.nonzero], self.zero)
+        self.assertEqual(amt.currency, self.nonzero.currency)
+        self.assertEqual(amt.value, self.nonzero.value)
+
+    def test_to_major_decimal(self):
+        self.assertEqual(self.zero.to_major_decimal(), Decimal('0'))
+
+    def test_unicode(self):
+        try:
+            unicode(self.zero)
+        except:
+            self.fail("unicode(self.zero) raised an exception")
+
+    def test_repr(self):
+        try:
+            repr(self.zero)
+        except:
+            self.fail("repr(self.zero) raised an exception")
+
+    def test_forbidden_from_code_and_minor(self):
+        with self.assertRaises(NotImplementedError):
+            ZeroAmount.from_code_and_minor('USD', 100)
+
+    def test_forbidden_from_code_and_major(self):
+        with self.assertRaises(NotImplementedError):
+            ZeroAmount.from_code_and_minor('USD', Decimal('1.00'))

--- a/currint/tests/test_amount.py
+++ b/currint/tests/test_amount.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from decimal import Decimal
 from unittest import TestCase
 from ..currency import currencies
-from ..amount import Amount, ZeroAmount
+from ..amount import Amount, _ZeroAmount
 
 
 class AmountTests(TestCase):
@@ -140,6 +140,9 @@ class ZeroAmountTests(TestCase):
     def setUp(self):
         self.nonzero = Amount(currencies["GBP"], 300)
 
+    def test_singleton(self):
+        self.assertIs(Amount.ZERO, _ZeroAmount())
+
     def test_simple_addition(self):
         amt = Amount.ZERO + self.nonzero
         self.assertEqual(amt.currency, self.nonzero.currency)
@@ -172,8 +175,8 @@ class ZeroAmountTests(TestCase):
 
     def test_forbidden_from_code_and_minor(self):
         with self.assertRaises(NotImplementedError):
-            ZeroAmount.from_code_and_minor('USD', 100)
+            _ZeroAmount.from_code_and_minor('USD', 100)
 
     def test_forbidden_from_code_and_major(self):
         with self.assertRaises(NotImplementedError):
-            ZeroAmount.from_code_and_minor('USD', Decimal('1.00'))
+            _ZeroAmount.from_code_and_minor('USD', Decimal('1.00'))

--- a/currint/tests/test_amount.py
+++ b/currint/tests/test_amount.py
@@ -138,38 +138,37 @@ class AmountTests(TestCase):
 
 class ZeroAmountTests(TestCase):
     def setUp(self):
-        self.zero = ZeroAmount()
         self.nonzero = Amount(currencies["GBP"], 300)
 
     def test_simple_addition(self):
-        amt = self.zero + self.nonzero
+        amt = Amount.ZERO + self.nonzero
         self.assertEqual(amt.currency, self.nonzero.currency)
         self.assertEqual(amt.value, self.nonzero.value)
 
     def test_simple_raddition(self):
-        amt = self.nonzero + self.zero
+        amt = self.nonzero + Amount.ZERO
         self.assertEqual(amt.currency, self.nonzero.currency)
         self.assertEqual(amt.value, self.nonzero.value)
 
     def test_sum(self):
-        amt = sum([self.nonzero], self.zero)
+        amt = sum([self.nonzero], Amount.ZERO)
         self.assertEqual(amt.currency, self.nonzero.currency)
         self.assertEqual(amt.value, self.nonzero.value)
 
     def test_to_major_decimal(self):
-        self.assertEqual(self.zero.to_major_decimal(), Decimal('0'))
+        self.assertEqual(Amount.ZERO.to_major_decimal(), Decimal('0'))
 
     def test_unicode(self):
         try:
-            unicode(self.zero)
+            unicode(Amount.ZERO)
         except:
-            self.fail("unicode(self.zero) raised an exception")
+            self.fail("unicode(Amount.ZERO) raised an exception")
 
     def test_repr(self):
         try:
-            repr(self.zero)
+            repr(Amount.ZERO)
         except:
-            self.fail("repr(self.zero) raised an exception")
+            self.fail("repr(Amount.ZERO) raised an exception")
 
     def test_forbidden_from_code_and_minor(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Allows using `sum()` on a list of `currint.Amount` values without having to know the currency upfront.

Makes writing code like this pythonic:
```
total = sum((fee.price for fee in fees), Amount.ZERO)
```