### PR TITLE
Generate string directly from major Decimal in Currency.format_decimal

### DIFF
--- a/currint/currency.py
+++ b/currint/currency.py
@@ -101,10 +101,17 @@ class Currency(object):
         Formats a value (in the minor unit as an integer) as a string,
         with no local prefix/suffix.  Can be cast into a Decimal value as needed.
         """
-        major_int = int(self.minor_to_major(value))
-        minor_int = abs(value) % self.divisor
-        format_str = "%i.%0" + str(self.exponent or 0) + "i"
-        return format_str % (major_int, minor_int)
+        major_value = self.minor_to_major(value)
+
+        if self.exponent is not None:
+            format_str = "{:.{precision}f}"
+            format_kwargs = dict(precision=self.exponent)
+        else:
+            # A custom `divisor` can produce arbitrary precision major representations (think divisor=13)
+            format_str = "{:f}"
+            format_kwargs = {}
+
+        return format_str.format(major_value, **format_kwargs)
 
 
 currencies = {

--- a/currint/tests/test_currency.py
+++ b/currint/tests/test_currency.py
@@ -35,8 +35,8 @@ class CurrencyTests(TestCase):
         )
         # Non-decimal currency
         self.assertEqual(
-            currencies["MRO"].minor_to_major(25),
-            Decimal("5"),
+            currencies["MRO"].minor_to_major(26),
+            Decimal("5.2"),
         )
 
     def test_format(self):
@@ -51,7 +51,18 @@ class CurrencyTests(TestCase):
         # Non-decimal currency
         self.assertEqual(
             currencies["MRO"].format(7),
-            "1.2 MRO",
+            "1.4 MRO",
+        )
+        # Negative value less than 0 and greater than -1 major unit
+        self.assertEqual(
+            currencies["USD"].format(-60),
+            "-0.60 USD",
+        )
+
+        # 0 exponent currency
+        self.assertEqual(
+            currencies["JPY"].format(100),
+            "100 JPY",
         )
 
     def test_format_decimal(self):
@@ -66,7 +77,19 @@ class CurrencyTests(TestCase):
         # Non-decimal currency
         self.assertEqual(
             currencies["MRO"].format_decimal(7),
-            "1.2",
+            "1.4",
+        )
+
+        # Negative value less than 0 and greater than -1 major unit
+        self.assertEqual(
+            currencies["USD"].format_decimal(-60),
+            "-0.60",
+        )
+
+        # 0 exponent currency
+        self.assertEqual(
+            currencies["JPY"].format_decimal(100),
+            "100",
         )
 
     def test_equality(self):


### PR DESCRIPTION
Closes #8, closes #9, and closes #10.  `Currency.format_decimal` produces a string representation of a minor value that can be converted back to a `Decimal`.  The previous approach separated the major and minor portions of the value and then passed them into a format string. This allowed

* Maximum control over formatting
* For custom `divisor` currencies, making the value after the "." the number of minor units instead of the proportion of a major unit

This had multiple downsides:

* A negative value greater than -1 major unit would be returned as a positive string because -0 is formatted as "0"
* Currencies with no minor unit were formatted with a trailing ".0"
* The `format_decimal` representation of non-decimal currencies cannot be passed as a `Decimal` into `Currency.major_to_minor_value` or `Amount.from_code_and_major`

The new approach creates a string representation of the value by formatting it's major `Decimal` equivalent.  This has several advantages:
* `format_decimal` doesn't have to handle formatting -0 because it always deals with the number as a whole (e.g. value=-60).
* Normal python format directives can be used to limit the precision of a single number in a declaritive way, naturally chopping off the trailing ".0" for 0 exponent currencies.
* The `Decimal` representation of non-decimal currencies accurately represents the fractional portion of major units

To accomodate this approach, this includes a deliberate and breaking change in representation of non-decimal currencies. Instead of returning them as "{major_units}.{minor_units}", it returns "{major_units}.{remaining_proportion_of_major_units}". For example, 6 minor units of MRO is now represented as "1.2" instead of "1.1" - each minor unit is 1/5th of a major unit.  This is consistent with the numeric `Currency` and `Amount` functions mentioned above.

New tests have been created for currencies with no minor units, and for the fractional negative value edge case.  Existing non-decimal currency tests have been updated.