### PR TITLE
Add Python 3 and latest Invoke (0.21.0) support to tasks.py

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,13 +1,13 @@
 import os
-import subprocess
 import currint
 from invoke import task
+from six.moves import input
 
 
 VERSION_FILE = os.path.join(os.path.dirname(currint.__file__), "__init__.py")
 
 
-def _write_to_version_file(version):
+def _write_to_version_file(ctx, version):
     with open(VERSION_FILE, 'r') as version_read:
         output = []
         for line in version_read:
@@ -21,43 +21,35 @@ def _write_to_version_file(version):
             version_write.write(line + '\n')
 
 
-def _commit_and_tag(version):
+def _commit_and_tag(ctx, version):
     """Commit changes to version file and tag the release"""
-    subprocess.check_call(
-        ['git', 'add', VERSION_FILE],
-    )
-    subprocess.check_call(
-        ['git', 'commit', '-m', "Releasing version %s" % version]
-    )
-    subprocess.check_call(
-        ['git', 'tag', version]
-    )
+    ctx.run('git add %s' % VERSION_FILE, hide='out')
+    ctx.run('git commit -m "Releasing version %s"' % version, hide='out')
+    ctx.run('git tag %s' % version, hide='out')
 
 
-def _push_release_changes(version):
-    push = raw_input('Push release changes to master? (y/n): ')
+def _push_release_changes(ctx, version):
+    push = input('Push release changes to master? (y/n): ')
     if push == 'y':
-        print subprocess.check_output(
-            ['git', 'push', 'origin', 'master']
-        )
+        ctx.run('git push origin master')
+
         # push the release tag
-        print subprocess.check_output(
-            ['git', 'push', 'origin', version]
-        )
+        ctx.run('git push origin %s' % version)
+
     else:
-        print 'Not pushing changes to master!'
-        print 'Make sure you remember to explictily push the tag!'
+        print('Not pushing changes to master!')
+        print('Make sure you remember to explictily push the tag!')
 
 
 @task
-def release():
+def release(ctx):
     # Prompt for version
-    print "Current version: %s" % currint.__version__
-    release_version = raw_input('Enter a new version (or "exit"): ')
+    print("Current version: %s" % currint.__version__)
+    release_version = input('Enter a new version (or "exit"): ')
     if not release_version or release_version == 'exit':
-        print 'Cancelling release!'
+        print('Cancelling release!')
         return
 
-    _write_to_version_file(release_version)
-    _commit_and_tag(release_version)
-    _push_release_changes(release_version)
+    _write_to_version_file(ctx, release_version)
+    _commit_and_tag(ctx, release_version)
+    _push_release_changes(ctx, release_version)


### PR DESCRIPTION
This makes it easier for someone to jump into development by running `pip install invoke`.

Tested by running on my fork's master with both versions of Python and 0.21.0 of invoke. Also compared the output of running `invoke release` with the update tasks and the tasks in the previous commit.