### PR TITLE
[PATCH] Add CI integration and Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+cache: pip
+install:
+  - pip install six
+  - pip install .
+script:
+  - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
   - '3.6'
   - '3.7'

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
-from setuptools import setup, find_packages
+from setuptools import (
+    find_packages,
+    setup,
+)
+
 from currint import __version__
+
 
 setup(
     name='currint',
@@ -24,7 +29,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development',
     ],
 )
-


### PR DESCRIPTION
* Add Travis CI configuration file, with all the supported Python versions.
* Add Python 3.7 to PyPI classifiers.
* Remove Python 3.4 from the list of supported versions (it still works, but won't be tested in newer versions).