### PR TITLE
Change BYR to BYN in accordance with 2016 change to ISO 4217

### DIFF
--- a/currint/currency.py
+++ b/currint/currency.py
@@ -139,7 +139,7 @@ currencies = {
     "BSD": Currency("BSD", "044", 2, 'Bahamian Dollar'),
     "BTN": Currency("BTN", "064", 2, 'Ngultrum'),
     "BWP": Currency("BWP", "072", 2, 'Pula'),
-    "BYR": Currency("BYR", "974", 0, 'Belarussian Ruble'),
+    "BYN": Currency("BYN", "933", 2, 'Belarussian Ruble'),
     "BZD": Currency("BZD", "084", 2, 'Belize Dollar'),
     "CAD": Currency("CAD", "124", 2, 'Canadian Dollar'),
     "CDF": Currency("CDF", "976", 2, 'Congolese Franc'),


### PR DESCRIPTION
In 2016 the BYR currency changed to BYN. See for more details:
https://en.wikipedia.org/wiki/Belarusian_ruble

as well as latest ISO 4217
https://www.iso.org/iso-4217-currency-codes.html
